### PR TITLE
Fix some typos, and reset the default shuffle and transform flag

### DIFF
--- a/mos_SalsaNext/salsanext_mos.yml
+++ b/mos_SalsaNext/salsanext_mos.yml
@@ -4,13 +4,13 @@
 train:
   loss: "xentropy"       # must be either xentropy or iou
   max_epochs: 150
-  lr: 0.01              # sgd learning rate
+  lr: 0.01               # sgd learning rate
   wup_epochs: 1          # warmup during first XX epochs (can be float)
   momentum: 0.9          # sgd momentum
   lr_decay: 0.99         # learning rate decay per epoch after initial cycle (from min lr)
   w_decay: 0.0001        # weight decay
-  batch_size: 1              # batch size
-  report_batch: 10        # every x batches, report loss
+  batch_size: 1          # batch size
+  report_batch: 10       # every x batches, report loss
   report_epoch: 1        # every x epochs, report validation set
   epsilon_w: 0.001       # class weight w = 1 / (content + epsilon_w)
   save_summary: False    # Summary of weight histograms for tensorboard
@@ -18,7 +18,7 @@ train:
     # sample images (one per batch of the last calculated batch)
   # in log folder
   show_scans: False      # show scans during training
-  workers: 4            # number of threads to get data
+  workers: 4             # number of threads to get data
   
   # for mos
   residual: True # This needs to be the same as in the dataset params below!
@@ -71,5 +71,5 @@ dataset:
       
     # for mos
     n_input_scans: 1 # This needs to be the same as in the backbone params above!
-    residual: Ture # This needs to be the same as in the backbone params above!
+    residual: True   # This needs to be the same as in the backbone params above!
     transform: False # tranform the last n_input_scans - 1 frames before concatenation

--- a/mos_SalsaNext/train/tasks/semantic/dataset/kitti/parser.py
+++ b/mos_SalsaNext/train/tasks/semantic/dataset/kitti/parser.py
@@ -428,13 +428,13 @@ class Parser():
                                          learning_map_inv=self.learning_map_inv,
                                          sensor=self.sensor,
                                          max_points=max_points,
-                                         # transform=True,
+                                         transform=True, # set to True to augment the data
                                          gt=self.gt)
   
       self.trainloader = torch.utils.data.DataLoader(self.train_dataset,
                                                      batch_size=self.batch_size,
-                                                     # shuffle=self.shuffle_train,
-                                                     shuffle=False,
+                                                     shuffle=self.shuffle_train, 
+                                                     # shuffle=False, # set False to ensure sequential loading
                                                      num_workers=self.workers,
                                                      drop_last=True)
       assert len(self.trainloader) > 0


### PR DESCRIPTION
- In config salsanext_mos.yml, change `residual = Ture` to `residual = True`
- Reset the default `shuffle` and `transform` flags for SemanticKitti dataloader